### PR TITLE
Fix `candy_taken` flag number in `undertale/flags.html`

### DIFF
--- a/public/undertale/flags.html
+++ b/public/undertale/flags.html
@@ -231,14 +231,14 @@
     </tr>
     <tr>
         <td>33</td>
-        <td>candy_taken</td>
-        <td>range</td>
+        <td>pushed_rock_4</td>
+        <td>bool</td>
         <td></td>
     </tr>
     <tr>
         <td>34</td>
-        <td>pushed_rock_4</td>
-        <td>bool</td>
+        <td>candy_taken</td>
+        <td>range</td>
         <td></td>
     </tr>
     <tr>


### PR DESCRIPTION
`candy_taken` is `global.flag[34]`, not `[33]`. (for Undertale v1.08)